### PR TITLE
feat: Update shop information and add shop detail page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -234,3 +234,53 @@ footer p {
         grid-template-columns: 1fr; /* Single column layout on very small screens */
     }
 }
+
+/* Styles for shop-detail.html */
+#shop-detail-container {
+    background-color: #fff; /* White background for the detail section */
+    padding: 20px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#shop-detail-container h2 {
+    color: #333; /* Darker heading color for shop name */
+}
+
+#shop-detail-container img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+    margin-bottom: 15px;
+}
+
+#shop-individuals-container {
+    background-color: #f9f9f9; /* Slightly different background for staff section */
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+#shop-individuals-container h2 {
+    color: #444; /* Heading color for staff section */
+    margin-bottom: 15px;
+}
+
+#individuals-list .individual-card {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    padding: 15px;
+    margin-bottom: 15px;
+    border-radius: 4px;
+}
+
+#individuals-list .individual-card h3 {
+    margin-top: 0;
+    color: #555;
+}
+
+#individuals-list .individual-card img {
+    border-radius: 4px;
+    margin-bottom: 10px;
+}

--- a/data/shops.json
+++ b/data/shops.json
@@ -1,11 +1,11 @@
 [
   {
     "id": "shop001",
-    "name": "くすぐり天国",
-    "description": "都心に佇む隠れ家のようなお店。極上のくすぐり体験をあなたに。",
-    "address_general": "東京都内某所",
-    "tags": ["ソフト", "手コキ", "オイル"],
-    "image_url": "images/shop_placeholder.png",
-    "website_url": null
+    "name": "くすぐり宅配便",
+    "description": "東京渋谷。日本唯一のくすぐりデリバリーエステ。くすぐり好きの欲望を誰にも遠慮する事なく「ぶつけて」、「爆発させて」、「発散させる」ことができる夢のお店♬",
+    "address_general": "東京都渋谷区",
+    "tags": ["デリバリーエステ", "くすぐり"],
+    "image_url": "https://kusuguritakuhaibin.com/wp-content/themes/SWELL_CHILD/logo.png",
+    "website_url": "https://kusuguritakuhaibin.com/"
   }
 ]

--- a/js/main.js
+++ b/js/main.js
@@ -55,12 +55,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const shopCard = document.createElement('div');
             shopCard.className = 'shop-card';
             shopCard.innerHTML = `
-                <h3>${shop.name}</h3>
+                <h3><a href="shop-detail.html?id=${shop.id}">${shop.name}</a></h3>
                 <img src="${shop.image_url || 'images/shop_placeholder.png'}" alt="${shop.name}" style="width:100%;max-width:300px;">
                 <p>${shop.description}</p>
                 <p class="address">場所: ${shop.address_general}</p>
-                <div class="tags">タグ: ${shop.tags.join(', ')}</div>
+                <div class="tags">タグ: ${Array.isArray(shop.tags) ? shop.tags.join(', ') : 'タグなし'}</div>
                 ${shop.website_url ? `<p><a href="${shop.website_url}" target="_blank" rel="noopener noreferrer">ウェブサイトを見る</a></p>` : ''}
+                <p><a href="shop-detail.html?id=${shop.id}">詳細を見る</a></p> 
             `;
             shopsContainer.appendChild(shopCard);
         });

--- a/js/shop-detail.js
+++ b/js/shop-detail.js
@@ -1,0 +1,90 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log("Shop detail page DOM fully loaded and parsed.");
+
+    // Get DOM elements
+    const shopNameElement = document.getElementById('shop-name');
+    const shopImageElement = document.getElementById('shop-image');
+    const shopDescriptionElement = document.getElementById('shop-description');
+    const shopAddressElement = document.getElementById('shop-address');
+    const shopTagsElement = document.getElementById('shop-tags');
+    const shopWebsiteElement = document.getElementById('shop-website');
+    const individualsListElement = document.getElementById('individuals-list');
+    const pageTitle = document.querySelector('title');
+
+    // Get shop ID from URL query parameter
+    const urlParams = new URLSearchParams(window.location.search);
+    const shopId = urlParams.get('id');
+
+    if (!shopId) {
+        if (shopNameElement) shopNameElement.textContent = 'お店のIDが見つかりません。';
+        console.error("Shop ID not found in URL parameters.");
+        return;
+    }
+
+    async function fetchAndDisplayShopDetails() {
+        try {
+            const shopsResponse = await fetch('data/shops.json');
+            if (!shopsResponse.ok) throw new Error(`HTTP error! status: ${shopsResponse.status} while fetching shops.json`);
+            const allShops = await shopsResponse.json();
+
+            const individualsResponse = await fetch('data/individuals.json');
+            if (!individualsResponse.ok) throw new Error(`HTTP error! status: ${individualsResponse.status} while fetching individuals.json`);
+            const allIndividuals = await individualsResponse.json();
+
+            const shop = allShops.find(s => s.id === shopId);
+
+            if (!shop) {
+                if (shopNameElement) shopNameElement.textContent = 'お店が見つかりません。';
+                console.error("Shop not found for ID:", shopId);
+                return;
+            }
+
+            // Populate shop details
+            if (pageTitle) pageTitle.textContent = `${shop.name} - お店の詳細 | くすぐりフェチ専科`;
+            if (shopNameElement) shopNameElement.textContent = shop.name;
+            if (shopImageElement) {
+                shopImageElement.src = shop.image_url || 'images/shop_placeholder.png';
+                shopImageElement.alt = shop.name;
+            }
+            if (shopDescriptionElement) shopDescriptionElement.textContent = shop.description;
+            if (shopAddressElement) shopAddressElement.textContent = `場所: ${shop.address_general}`;
+            if (shopTagsElement) shopTagsElement.textContent = `タグ: ${Array.isArray(shop.tags) ? shop.tags.join(', ') : 'なし'}`;
+            if (shopWebsiteElement) {
+                if (shop.website_url) {
+                    shopWebsiteElement.innerHTML = `<a href="${shop.website_url}" target="_blank" rel="noopener noreferrer">ウェブサイトを見る</a>`;
+                } else {
+                    shopWebsiteElement.innerHTML = 'ウェブサイトなし';
+                }
+            }
+
+            // Filter and display individuals for this shop
+            const shopIndividuals = allIndividuals.filter(ind => ind.shop_id === shopId);
+            if (individualsListElement) {
+                individualsListElement.innerHTML = ''; // Clear loading message
+                if (shopIndividuals.length > 0) {
+                    shopIndividuals.forEach(individual => {
+                        const individualCard = document.createElement('div');
+                        individualCard.className = 'individual-card'; // Reuse class from main.js for styling
+                        individualCard.innerHTML = `
+                            <h3>${individual.name}</h3>
+                            <img src="${individual.image_url || 'images/individual_placeholder.png'}" alt="${individual.name}" style="width:100%;max-width:200px;">
+                            <p>${individual.bio}</p>
+                            <div class="tags">タグ: ${Array.isArray(individual.tags) ? individual.tags.join(', ') : 'なし'}</div>
+                        `;
+                        individualsListElement.appendChild(individualCard);
+                    });
+                } else {
+                    individualsListElement.innerHTML = '<p>このお店に所属している女の子の情報はまだありません。</p>';
+                }
+            }
+            console.log("Shop details and individuals rendered for shop ID:", shopId);
+
+        } catch (error) {
+            console.error("Failed to fetch or display shop details:", error);
+            if (shopNameElement) shopNameElement.textContent = '情報の読み込みに失敗しました。';
+            if (individualsListElement) individualsListElement.innerHTML = `<p>情報の読み込みに失敗しました。詳細: ${error.message}</p>`;
+        }
+    }
+
+    fetchAndDisplayShopDetails();
+});

--- a/shop-detail.html
+++ b/shop-detail.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>お店の詳細 - くすぐりフェチ専科</title>
+    <link rel="stylesheet" href="css/style.css">
+    <meta name="robots" content="noindex"> <!-- Assuming detail pages should not be indexed -->
+</head>
+<body>
+    <header>
+        <h1><a href="index.html">くすぐりフェチ専科</a></h1>
+        <!-- Breadcrumb or back link can be added here if desired -->
+    </header>
+
+    <main>
+        <section id="shop-detail-container">
+            <!-- Shop details will be populated here by JavaScript -->
+            <h2 id="shop-name">お店の情報を読み込み中...</h2>
+            <img id="shop-image" src="images/shop_placeholder.png" alt="お店の画像" style="width:100%;max-width:400px;">
+            <p id="shop-description"></p>
+            <p id="shop-address"></p>
+            <div id="shop-tags" class="tags"></div>
+            <p id="shop-website"></p>
+        </section>
+
+        <section id="shop-individuals-container">
+            <h2>所属している女の子</h2>
+            <div id="individuals-list">
+                <!-- Individuals associated with the shop will be populated here by JavaScript -->
+                <p>女の子の情報を読み込み中...</p>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2023 くすぐりフェチ専科. All rights reserved.</p>
+    </footer>
+
+    <script src="js/shop-detail.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This commit implements the following changes:

1.  **Updated Shop Information:**
    *   The shop previously named "くすぐり天国" (ID: shop001) in `data/shops.json` has been updated to "くすぐり宅配便".
    *   Information (description, address, tags, image URL, website URL) for "くすぐり宅配便" has been populated using details from its official website.

2.  **Added Shop Detail Page (`shop-detail.html`):**
    *   A new `shop-detail.html` page has been created to display comprehensive information for a single shop.
    *   This page dynamically loads shop data using `js/shop-detail.js`.
    *   It includes the shop's name, image, description, address, tags, and a link to its website.

3.  **Display Associated Staff:**
    *   The `shop-detail.html` page now lists the staff members (individuals) associated with the displayed shop.
    *   Staff details (name, image, bio, tags) are loaded from `data/individuals.json`.

4.  **Navigation:**
    *   `js/main.js` has been modified so that shop names and a new "詳細を見る" (View Details) link on the main page's shop cards now link to the respective `shop-detail.html?id={shop_id}`.

5.  **Styling:**
    *   Basic CSS styles have been added to `css/style.css` to improve the layout and presentation of the new `shop-detail.html` page and its components.

The external image URL for "くすぐり宅配便" is taken directly from their website. Its successful rendering should be verified in a live browser environment.