### PR TITLE
Fix footer year on shop detail page

### DIFF
--- a/shop-detail.html
+++ b/shop-detail.html
@@ -34,7 +34,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2023 くすぐりフェチ専科. All rights reserved.</p>
+        <p>&copy; 2025 くすぐりフェチ専科. All rights reserved.</p>
     </footer>
 
     <script src="js/shop-detail.js"></script>


### PR DESCRIPTION
## Summary
- correct footer year to 2025 in `shop-detail.html`

## Testing
- `grep -n "2025" shop-detail.html`

------
https://chatgpt.com/codex/tasks/task_e_6843f8a1cfd0832eb69ccd7922d6b45d