### PR TITLE
Add about and shop detail pages to sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,8 +2,74 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://maru-tk-dev.github.io/tickle_brothel/</loc>
-    <lastmod>2025-06-29</lastmod> <!-- Updated to current date during execution -->
+    <lastmod>2025-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/about.html</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop001</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop002</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop003</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop004</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop005</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop006</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop007</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop008</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop009</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/shop-detail.html?id=shop010</loc>
+    <lastmod>2025-06-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- include about page in `sitemap.xml`
- list every shop detail URL with current `lastmod`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860104cff68832eac472a7625b960da