### PR TITLE
Add regional shop pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
         <nav>
             <!-- 将来的なナビゲーションリンクのためにコメントアウトしておく -->
             <!-- <a href="#shops-listings">お店一覧</a> | <a href="#individuals-listings">女の子一覧</a> -->
+            <a href="tokyo.html">東京のお店</a> |
+            <a href="osaka.html">大阪のお店</a> |
+            <a href="nagoya.html">名古屋のお店</a> |
             <a href="about.html">このサイトについて</a>
         </nav>
     </header>

--- a/js/region.js
+++ b/js/region.js
@@ -1,0 +1,43 @@
+// region.js - display shops filtered by region
+
+document.addEventListener('DOMContentLoaded', () => {
+    const region = document.body.dataset.region;
+    const shopsContainer = document.getElementById('shops-container');
+
+    function renderShops(shops) {
+        shopsContainer.innerHTML = '';
+        if (!shops.length) {
+            shopsContainer.innerHTML = '<p>該当するお店が見つかりませんでした。</p>';
+            return;
+        }
+        shops.forEach(shop => {
+            const card = document.createElement('div');
+            card.className = 'shop-card';
+            card.innerHTML = `
+                <h3><a href="shop-detail.html?id=${shop.id}">${shop.name}</a></h3>
+                <img src="${shop.image_url || 'images/shop_placeholder.png'}" alt="${shop.name}" style="width:100%;max-width:300px;height:auto;object-fit:contain;">
+                <p>${shop.description}</p>
+                <p class="address">場所: ${shop.address_general}</p>
+                <div class="tags">タグ: ${Array.isArray(shop.tags) ? shop.tags.join(', ') : 'タグなし'}</div>
+                ${shop.website_url ? `<p><a href="${shop.website_url}" target="_blank" rel="noopener noreferrer">ウェブサイトを見る</a></p>` : ''}
+                <p><a href="shop-detail.html?id=${shop.id}">詳細を見る</a></p>
+            `;
+            shopsContainer.appendChild(card);
+        });
+    }
+
+    async function fetchShops() {
+        try {
+            const res = await fetch('data/shops.json');
+            if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+            const data = await res.json();
+            const filtered = data.filter(shop => Array.isArray(shop.tags) && shop.tags.includes(region));
+            renderShops(filtered);
+        } catch (err) {
+            console.error('Failed to load shops:', err);
+            shopsContainer.innerHTML = `<p>データの読み込みに失敗しました。詳細: ${err.message}</p>`;
+        }
+    }
+
+    fetchShops();
+});

--- a/nagoya.html
+++ b/nagoya.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>名古屋のお店一覧 | くすぐりフェチ専科</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body data-region="名古屋">
+    <header>
+        <h1>名古屋のお店一覧</h1>
+        <nav>
+            <a href="index.html">トップページへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>お店一覧</h2>
+            <div id="shops-container">
+                <p>お店の情報を読み込み中...</p>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2025 くすぐりフェチ専科. All rights reserved.</p>
+    </footer>
+    <script src="js/region.js"></script>
+</body>
+</html>

--- a/osaka.html
+++ b/osaka.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>大阪のお店一覧 | くすぐりフェチ専科</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body data-region="大阪">
+    <header>
+        <h1>大阪のお店一覧</h1>
+        <nav>
+            <a href="index.html">トップページへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>お店一覧</h2>
+            <div id="shops-container">
+                <p>お店の情報を読み込み中...</p>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2025 くすぐりフェチ専科. All rights reserved.</p>
+    </footer>
+    <script src="js/region.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,22 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/tokyo.html</loc>
+    <lastmod>2025-06-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/osaka.html</loc>
+    <lastmod>2025-06-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://maru-tk-dev.github.io/tickle_brothel/nagoya.html</loc>
+    <lastmod>2025-06-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/tokyo.html
+++ b/tokyo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>東京のお店一覧 | くすぐりフェチ専科</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body data-region="東京">
+    <header>
+        <h1>東京のお店一覧</h1>
+        <nav>
+            <a href="index.html">トップページへ戻る</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>お店一覧</h2>
+            <div id="shops-container">
+                <p>お店の情報を読み込み中...</p>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2025 くすぐりフェチ専科. All rights reserved.</p>
+    </footer>
+    <script src="js/region.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add pages for Tokyo, Osaka, and Nagoya shops
- filter regional pages with new `region.js`
- link regional pages from the home page
- list new pages in `sitemap.xml`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68601065f908832ea185a8a05e7a6cf8